### PR TITLE
fix(examples): 添加 import map 解决 lodash-es 模块无法解析的问题

### DIFF
--- a/examples/merger/web.html
+++ b/examples/merger/web.html
@@ -83,6 +83,13 @@
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     ></script>
+    <script type="importmap">
+      {
+        "imports": {
+          "lodash-es": "https://esm.sh/lodash-es@4.17.21"
+        }
+      }
+    </script>
     <script type="module">
       import * as merger from '../../dist/es/ztool.min.js';
 

--- a/examples/tools/web.html
+++ b/examples/tools/web.html
@@ -122,6 +122,13 @@
       <button id="errorTrapBtn">测试接口</button>
     </section>
 
+    <script type="importmap">
+      {
+        "imports": {
+          "lodash-es": "https://esm.sh/lodash-es@4.17.21"
+        }
+      }
+    </script>
     <script type="module">
       import * as tools from '../../dist/es/ztool.min.js';
 


### PR DESCRIPTION
## 问题

在浏览器中直接使用 ES Module 方式加载 `dist/es/ztool.min.js` 时，报错：

> Uncaught TypeError: Failed to resolve module specifier "lodash-es". Relative references must start with either "/", "./", or "../".

## 原因

Vite 构建配置中将 `lodash-es` 标记为 `external`，构建产物中保留了 `import { ... } from "lodash-es"` 的裸模块说明符，而浏览器原生不支持这类说明符。

## 修复

在两个示例 HTML 文件中添加 `<script type="importmap">`，将 `lodash-es` 映射到 `esm.sh` CDN，使浏览器能够正确解析 ESM 格式的 lodash-es 模块。

### 改动文件

- `examples/merger/web.html` — 添加 import map
- `examples/tools/web.html` — 添加 import map

🤖 Generated with [Claude Code](https://claude.com/claude-code)